### PR TITLE
wtf_log_callback_t to use user provided context

### DIFF
--- a/include/wtf.h
+++ b/include/wtf.h
@@ -315,8 +315,9 @@ typedef void (*wtf_stream_callback_t)(const wtf_stream_event_t* event);
 //! @param file source file name
 //! @param line source file line number
 //! @param message formatted log message
+//! @param user_context user provided context (see wtf_context_config_t::log_user_context)
 typedef void (*wtf_log_callback_t)(wtf_log_level_t level, const char* component, const char* file,
-                                   int line, const char* message);
+                                   int line, const char* message, void* user_context);
 
 // #endregion
 

--- a/src/log.c
+++ b/src/log.c
@@ -17,7 +17,7 @@ void wtf_log_internal(wtf_context* ctx, wtf_log_level_t level, const char* compo
     char message[1024];
     vsnprintf(message, sizeof(message), format, args);
 
-    ctx->log_callback(level, component, file, line, message);
+    ctx->log_callback(level, component, file, line, message, ctx->log_user_context);
 
     va_end(args);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Logging callbacks now receive an additional user context parameter, enabling per-context data to be passed through. Existing callback implementations must be updated to accept the new argument.
* **Documentation**
  * Updated logging documentation to reference the new user context parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->