### PR TITLE
Normalized send memory allocation: added user context associated with…

### DIFF
--- a/include/wtf.h
+++ b/include/wtf.h
@@ -260,7 +260,7 @@ typedef struct {
 typedef struct {
     wtf_stream_event_type_t type;  //! Type of stream event
     wtf_stream_t* stream;          //! Stream that generated the event
-    void* user_context;            //! User-provided context data
+    void* user_context;            //! User-provided context data (wtf_stream_set_context)
 
     union {
         struct {
@@ -272,6 +272,7 @@ typedef struct {
         struct {
             wtf_buffer_t* buffers;  //! Array of sent data buffers
             uint32_t buffer_count;  //! Number of buffers sent
+            void* user_context;     //! User-provided context data (wtf_stream_send)
             bool cancelled;         //! True if send was cancelled
         } send_complete;
 
@@ -556,6 +557,7 @@ WTF_API void* wtf_session_get_context(wtf_session_t* session);
 //! @param buffers array of data buffers to send
 //! @param buffer_count number of buffers in array
 //! @param fin true if this is the final data
+//! @param user_context an opaque context to be passed back to the caller on completion
 //! @return WTF_SUCCESS on success, error code on failure
 //!
 //! @note Memory ownership:
@@ -575,7 +577,7 @@ WTF_API void* wtf_session_get_context(wtf_session_t* session);
 //! @note The function passes the original buffers directly to the QUIC layer without
 //! modification or copying. No protocol headers are added for stream data.
 WTF_API wtf_result_t wtf_stream_send(wtf_stream_t* stream, const wtf_buffer_t* buffers,
-                                     uint32_t buffer_count, bool fin);
+                                     uint32_t buffer_count, bool fin, void* user_context);
 
 //! Close a stream gracefully (send FIN)
 //! @param stream stream to close

--- a/src/stream.c
+++ b/src/stream.c
@@ -295,7 +295,6 @@ static void wtf_stream_cleanup_send_context(wtf_stream* stream, wtf_internal_sen
         }
     }
 
-    free(send_ctx->buffers);
     free(send_ctx);
 }
 
@@ -499,7 +498,6 @@ void* wtf_stream_get_context(wtf_stream_t* stream)
     return ((wtf_stream*)stream)->user_context;
 }
 
-
 void wtf_stream_set_callback(wtf_stream_t* stream, wtf_stream_callback_t callback)
 {
     if (!stream) {
@@ -573,34 +571,34 @@ wtf_result_t wtf_stream_send(wtf_stream* stream, const wtf_buffer_t* buffers, ui
         return validation_result;
     }
 
-    wtf_internal_send_context* send_ctx = malloc(sizeof(wtf_internal_send_context));
+    wtf_internal_send_context* send_ctx = malloc(
+        sizeof(wtf_internal_send_context)
+        + (sizeof(wtf_buffer_t) + sizeof(QUIC_BUFFER)) * buffer_count);
     if (!send_ctx) {
         return WTF_ERROR_OUT_OF_MEMORY;
     }
-    wtf_buffer_t* internal_buffers = malloc(sizeof *buffers * buffer_count);
-    if (!internal_buffers) {
-        free(send_ctx);
-        return WTF_ERROR_OUT_OF_MEMORY;
-    }
-    memcpy(internal_buffers, buffers, sizeof *buffers * buffer_count);
 
-    send_ctx->buffers = internal_buffers;
+    send_ctx->buffers = (wtf_buffer_t*)(send_ctx + 1);  // A copy used to report completion
     send_ctx->count = buffer_count;
+    send_ctx->quic_buffers = (QUIC_BUFFER*)(send_ctx->buffers
+                                            + buffer_count);  // conversion to underlying QUIC
     send_ctx->user_context = user_context;
     send_ctx->internal_send = false;
+
+    for (uint32_t buffer_index = 0; buffer_index < buffer_count; buffer_index++) {
+        send_ctx->buffers[buffer_index] = buffers[buffer_index];
+        send_ctx->quic_buffers[buffer_index].Length = buffers[buffer_index].length;
+        send_ctx->quic_buffers[buffer_index].Buffer = buffers[buffer_index].data;
+    }
 
     QUIC_SEND_FLAGS flags = QUIC_SEND_FLAG_NONE;
     if (fin) {
         flags |= QUIC_SEND_FLAG_FIN;
     }
 
-    // WARN: QUIC_BUFFER cast below is not quite safe, this should be really done differently, 
-    //       either QUIC_BUFFER is to use used directly or there should be a static assert
-    //       of some way to ensure the match. So far this runs on affinity assumption.
-
     wtf_connection* conn = stream->session->connection;
     QUIC_STATUS status = conn->server->context->quic_api->StreamSend(
-        stream->quic_stream, (QUIC_BUFFER*)internal_buffers, buffer_count, flags, send_ctx);
+        stream->quic_stream, send_ctx->quic_buffers, buffer_count, flags, send_ctx);
 
     if (QUIC_SUCCEEDED(status)) {
         stream->state = WTF_INTERNAL_STREAM_STATE_OPEN;
@@ -610,7 +608,6 @@ wtf_result_t wtf_stream_send(wtf_stream* stream, const wtf_buffer_t* buffers, ui
         return WTF_SUCCESS;
     }
 
-    free(send_ctx->buffers);
     free(send_ctx);
     return wtf_quic_status_to_result(status);
 }

--- a/src/stream.c
+++ b/src/stream.c
@@ -284,6 +284,7 @@ static void wtf_stream_cleanup_send_context(wtf_stream* stream, wtf_internal_sen
             .user_context = stream->user_context,
             .send_complete = {.buffers = send_ctx->buffers,
                               .buffer_count = send_ctx->count,
+                              .user_context = send_ctx->user_context,
                               .cancelled = cancelled}};
         stream->callback(&event);
     } else {
@@ -565,7 +566,7 @@ static wtf_result_t wtf_stream_validate_send_params(wtf_stream* stream, const wt
 }
 
 wtf_result_t wtf_stream_send(wtf_stream* stream, const wtf_buffer_t* buffers, uint32_t buffer_count,
-                             bool fin)
+                             bool fin, void* user_context)
 {
     wtf_result_t validation_result = wtf_stream_validate_send_params(stream, buffers, buffer_count);
     if (validation_result != WTF_SUCCESS) {
@@ -576,9 +577,16 @@ wtf_result_t wtf_stream_send(wtf_stream* stream, const wtf_buffer_t* buffers, ui
     if (!send_ctx) {
         return WTF_ERROR_OUT_OF_MEMORY;
     }
+    wtf_buffer_t* internal_buffers = malloc(sizeof *buffers * buffer_count);
+    if (!internal_buffers) {
+        free(send_ctx);
+        return WTF_ERROR_OUT_OF_MEMORY;
+    }
+    memcpy(internal_buffers, buffers, sizeof *buffers * buffer_count);
 
-    send_ctx->buffers = (wtf_buffer_t*)buffers;
+    send_ctx->buffers = internal_buffers;
     send_ctx->count = buffer_count;
+    send_ctx->user_context = user_context;
     send_ctx->internal_send = false;
 
     QUIC_SEND_FLAGS flags = QUIC_SEND_FLAG_NONE;
@@ -586,9 +594,13 @@ wtf_result_t wtf_stream_send(wtf_stream* stream, const wtf_buffer_t* buffers, ui
         flags |= QUIC_SEND_FLAG_FIN;
     }
 
+    // WARN: QUIC_BUFFER cast below is not quite safe, this should be really done differently, 
+    //       either QUIC_BUFFER is to use used directly or there should be a static assert
+    //       of some way to ensure the match. So far this runs on affinity assumption.
+
     wtf_connection* conn = stream->session->connection;
     QUIC_STATUS status = conn->server->context->quic_api->StreamSend(
-        stream->quic_stream, (QUIC_BUFFER*)buffers, buffer_count, flags, send_ctx);
+        stream->quic_stream, (QUIC_BUFFER*)internal_buffers, buffer_count, flags, send_ctx);
 
     if (QUIC_SUCCEEDED(status)) {
         stream->state = WTF_INTERNAL_STREAM_STATE_OPEN;
@@ -598,6 +610,7 @@ wtf_result_t wtf_stream_send(wtf_stream* stream, const wtf_buffer_t* buffers, ui
         return WTF_SUCCESS;
     }
 
+    free(send_ctx->buffers);
     free(send_ctx);
     return wtf_quic_status_to_result(status);
 }
@@ -656,7 +669,7 @@ wtf_result_t wtf_stream_close(wtf_stream_t* stream)
     mtx_unlock(&strm->mutex);
 
     wtf_buffer_t empty_buffer = {0, NULL};
-    return wtf_stream_send(strm, &empty_buffer, 1, true);
+    return wtf_stream_send(strm, &empty_buffer, 1, true, NULL);
 }
 
 wtf_result_t wtf_stream_get_id(wtf_stream_t* stream, uint64_t* stream_id)

--- a/src/types.h
+++ b/src/types.h
@@ -323,6 +323,7 @@ typedef struct {
     wtf_buffer_t* buffers;
     uint32_t count;
     void* user_context;
+    QUIC_BUFFER* quic_buffers;
     wtf_session* session;
     bool internal_send;
 } wtf_internal_send_context;

--- a/src/types.h
+++ b/src/types.h
@@ -322,6 +322,7 @@ typedef struct wtf_context {
 typedef struct {
     wtf_buffer_t* buffers;
     uint32_t count;
+    void* user_context;
     wtf_session* session;
     bool internal_send;
 } wtf_internal_send_context;


### PR DESCRIPTION
… sent buffers; fixed ownership over buffer array

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-send user context for stream sends — callers can attach a context pointer to each send, and it is returned with the send-complete event.
  * Stream-close preserves prior behavior when no per-send context is provided.

* **Documentation**
  * API docs updated to describe the new per-send context parameter and its propagation to send-complete events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->