### PR TITLE
Option to pass through the MSBuild .targets file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,9 @@ else()
 endif()
 
 
-if(WTF_USE_EXTERNAL_MSQUIC)
+if (WTF_USE_EXTERNAL_MSQUIC AND MSQUIC_LIBRARIES MATCHES "targets$")
+    # pass through the msbuild .targets file
+elseif(WTF_USE_EXTERNAL_MSQUIC)
     find_package(msquic CONFIG REQUIRED)
     set(MSQUIC_LIBRARIES msquic)
 else()


### PR DESCRIPTION
Hi, thanks for sharing this WebTransport implementation. Very neat!

On my Mac I was able to use `-DWTF_USE_EXTERNAL_MSQUIC=on` to compile against libmsquic provided by Homebrew. Great.

On Windows though I was stuck compiling MsQuic from source. Not the end of the world but a bit annoying. Then while setting up some C# bindings I noticed that the MsQuic packages on NuGet include a .targets file which Visual Studio can use. Interesting but I could not for the life of me get CMake `find_package()` to pick up the .targets file.

I ended up making a small change to CMakeLists.txt so that cmake configure works by:
```
cmake -S . -B build
-DWTF_USE_EXTERNAL_MSQUIC=on
-DMSQUIC_LIBRARIES="c:\\users\\jd\\.nuget\\packages\\microsoft.native.quic.msquic.openssl\\2.5.6\\build\\native\\Microsoft.Native.Quic.MsQuic.quictls.targets"
```

Huzzah! Not sure if it helps other people but I offer this pull request just in case it does. Or if someone out there knows how to get `find_package()` to provide a .targets file then please let me know. Cheers.